### PR TITLE
Add clangd as default server for C++

### DIFF
--- a/LanguageServers.md
+++ b/LanguageServers.md
@@ -1,6 +1,6 @@
 # List of language servers & how to get them
 
-* [C](#c)
+* [C/C++](#cc)
 * [Clojure](#clojure)
 * [Crystal](#crystal)
 * [Go](#go)
@@ -14,7 +14,7 @@
 * [Rust](#rust)
 * [Zig](#zig)
 
-## C
+## C/C++
 
 - [Clangd](https://clangd.llvm.org/)
   - Installation: [instructions](https://clangd.llvm.org/installation.html)

--- a/config.lua
+++ b/config.lua
@@ -124,6 +124,7 @@ settings = {
     -- Language server to use when `lsp` command is executed without args
     defaultLanguageServer = {
         c          = languageServer.clangd,
+    	["c++"]    = languageServer.clangd,
         clojure    = languageServer.clojurelsp,
         crystal    = languageServer.crystalline,
         go         = languageServer.gopls,


### PR DESCRIPTION
Was editing some C++ and noticed there was no default server for it, so I just thought I'd add one real quick :)