### PR TITLE
Improve `hover` and `find-references` output

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -471,7 +471,7 @@ function LSPClient:handleResponseResult(method, result)
             else
                 table.insert(symbolLocations, sym.location)
             end
-            table.insert(symbolLabels, string.format("[%s]\t%s", SYMBOLKINDS[sym.kind], sym.name))
+            table.insert(symbolLabels, string.format("%-15s %s", "["..SYMBOLKINDS[sym.kind].."]", sym.name))
         end
         showSymbolLocations("document symbols", symbolLocations, symbolLabels)
     else

--- a/main.lua
+++ b/main.lua
@@ -1212,16 +1212,13 @@ function absPathFromFileUri(uri)
 end
 
 function relPathFromFileUri(uri)
-    local uriPath = absPathFromFileUri(uri)
-    local absPath, err = filepath.Abs(uriPath)
+    local absPath = absPathFromFileUri(uri)
+    local cwd, err = go_os.Getwd()
     if err then return absPath end
-
-    local cwd
-    cwd, err = go_os.Getwd()
+    local relPath
+    relPath, err = filepath.Rel(cwd, absPath)
     if err then return absPath end
-
-    -- +1 (slash after cwd) +1 (next position)
-    return string.sub(absPath, #cwd + 2, #absPath)
+    return relPath
 end
 
 function openFileAtLoc(filepath, loc)

--- a/main.lua
+++ b/main.lua
@@ -278,13 +278,6 @@ function LSPClient:handleResponseError(method, error)
     end
 end
 
-function showHoverInfo(results)
-    local bf = buffer.NewBuffer(results, "[µlsp] hover")
-    bf.Type.Scratch = true
-    bf.Type.Readonly = true
-    micro.CurPane():HSplitIndex(bf, true)
-end
-
 function LSPClient:handleResponseResult(method, result)
     if method == "initialize" then
         self.serverCapabilities = result.capabilities
@@ -304,7 +297,14 @@ function LSPClient:handleResponseResult(method, result)
         -- FIXME: iterate over *all* currently open buffers
         onBufferOpen(micro.CurPane().Buf)
     elseif method == "textDocument/hover" then
-        -- result.contents being a string or array is deprecated but as of 2023
+        local showHoverInfo = function (results)
+            local bf = buffer.NewBuffer(results, "[µlsp] hover")
+            bf.Type.Scratch = true
+            bf.Type.Readonly = true
+            micro.CurPane():HSplitIndex(bf, true)
+        end
+		
+	-- result.contents being a string or array is deprecated but as of 2023
         -- * pylsp still responds with {"contents": ""} for no results
         -- * lua-lsp still responds with {"contents": []} for no results
         if result == nil or result.contents == "" or table.empty(result.contents) then

--- a/main.lua
+++ b/main.lua
@@ -1294,16 +1294,9 @@ function showReferenceLocations(newBufferTitle, lspLocations)
     end
 
     table.sort(references, function(a, b)
-        if a.path < b.path then return true
-        elseif a.path > b.path then return false
-        else
-            if a.line < b.line then return true
-            elseif a.line > b.line then return false
-            else
-                if a.column < b.column then return true
-                elseif a.column > b.column then return false
-                else return true end
-            end
+        if a.path ~= b.path then return a.path < b.path end
+        if a.line ~= b.line then return a.line < b.line end
+        return a.column < b.column
         end
     end)
 


### PR DESCRIPTION
Changes:

 - Add line content and replace absolute with relative path in `showLocations()`. Instead of showing only the absolute path of the reference found, this patch adds the line content with `getLineContentFromPath()`. This new function will return a string with the content of the line or, in case of error, an error message. Also replaces the absolute path with the relative path in order to  shorten it and leave more space for the line content. For this task  `relPathFromFileUri()` was implemented.

 - Add `showHoverInfo()` to create an horizontal split with hover results.