### PR TITLE
Create a command completer for LSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,34 +23,34 @@ programming languages you want to use.
 
 The plugin currently provides following commands:
 
-- `lsp deno lsp` starts a language server by executing command `deno lsp`.
-  Without arguments the `lsp` command will try to guess the right server by
+- `lsp start deno lsp` starts a language server by executing command `deno lsp`.
+  Without arguments the `lsp start` command will try to guess the right server by
   looking at the currently open filetype.
-- `lsp-stop deno` stops the language server with name `deno`. Without arguments
-  the `lsp-stop` command will stop _all_ currently running language servers.
-- `hover` shows hover information for the code under cursor.
-- `format` formats the buffer that is currently open.
-- `autocomplete` for code completion suggestions. PROTIP: If you wish to use the
+- `lsp stop deno` stops the language server with name `deno`. Without arguments
+  the `lsp stop` command will stop _all_ currently running language servers.
+- `lsp hover` shows hover information for the code under cursor.
+- `lsp format` formats the buffer that is currently open.
+- `lsp autocomplete` for code completion suggestions. PROTIP: If you wish to use the
   same key as micro's autocompletion (tab by default), enable `tabAutocomplete`
   in `config.lua` instead of binding `command:autocomplete` to a key!
-- `goto-definition` – open the definition for the symbol under cursor
-- `goto-declaration` – open the declaration for the symbol under cursor
-- `goto-typedefinition` – open the type definition for the symbol under cursor
-- `goto-implementation` – open the implementation for the symbol under cursor
-- `find-references` - find all references to the symbol under cursor (shows the results in a new pane)
-- `document-symbols` - list all symbols in the current document
-- `diagnostic-info` - show more information about a diagnostic on the current line (useful for multiline diagnostic messages)
+- `lsp goto-definition` – open the definition for the symbol under cursor
+- `lsp goto-declaration` – open the declaration for the symbol under cursor
+- `lsp goto-typedefinition` – open the type definition for the symbol under cursor
+- `lsp goto-implementation` – open the implementation for the symbol under cursor
+- `lsp find-references` - find all references to the symbol under cursor (shows the results in a new pane)
+- `lsp document-symbols` - list all symbols in the current document
+- `lsp diagnostic-info` - show more information about a diagnostic on the current line (useful for multiline diagnostic messages)
 
 You can type the commands on micro command prompt or bind them to keys by adding
 something like this to your `bindings.json`:
 
 ```json
 {
-  "F7": "command:lsp",
-  "F8": "command:format",
-  "Alt-h": "command:hover",
-  "Alt-d": "command:goto-definition",
-  "Alt-r": "command:find-references"
+  "F7": "command:lsp start",
+  "F8": "command:lsp format",
+  "Alt-h": "command:lsp hover",
+  "Alt-d": "command:lsp goto-definition",
+  "Alt-r": "command:lsp find-references"
 }
 ```
 
@@ -70,7 +70,7 @@ something like this to your `bindings.json`:
 - [x] list document symbols
 - [ ] rename symbol
 - [ ] code actions
-- [ ] incremental document synchronization (better performance when editing large files)
+- [x] incremental document synchronization (better performance when editing large files)
 - [ ] [suggest a feature](https://github.com/Andriamanitra/mlsp/issues/new)
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The plugin currently provides following commands:
 - `lsp format` formats the buffer that is currently open.
 - `lsp autocomplete` for code completion suggestions. PROTIP: If you wish to use the
   same key as micro's autocompletion (tab by default), enable `tabAutocomplete`
-  in `config.lua` instead of binding `command:autocomplete` to a key!
+  in `config.lua` instead of binding `command:lsp autocomplete` to a key!
 - `lsp goto-definition` – open the definition for the symbol under cursor
 - `lsp goto-declaration` – open the declaration for the symbol under cursor
 - `lsp goto-typedefinition` – open the type definition for the symbol under cursor

--- a/main.lua
+++ b/main.lua
@@ -1,4 +1,4 @@
-VERSION = "0.1.0"
+VERSION = "0.2.0"
 
 local micro = import("micro")
 local config = import("micro/config")

--- a/main.lua
+++ b/main.lua
@@ -27,7 +27,7 @@ function init()
         ["goto-implementation"] = gotoAction("implementation"),
         ["goto-typedefinition"] = gotoAction("typeDefinition"),
         ["hover"]               = hoverAction,
-        ["sync-document"]       = syncFullDocument,
+        ["sync-document"]       = function (bp) syncFullDocument(bp.Buf) end,
         ["autocomplete"]        = completionAction,
         ["showlog"]             = showLog,
     }

--- a/main.lua
+++ b/main.lua
@@ -1377,7 +1377,7 @@ local function lspCompleter(buf)
     for i=1,#opts do
         local opt = opts[i]
         local startIdx, endIdx = string.find(opt, lastArg, 1, true)
-        if endIdx and startIdx == 1 then
+        if startIdx == 1 then
             local completion = string.sub(opt, endIdx + 1, #opt)
             table.insert(completions, completion)
             table.insert(suggestions, opt)


### PR DESCRIPTION
Group all the commands together as arguments for the main command `lsp`. This approach prevents the editor's command bar from becoming overcrowded with individual commands, making it simpler for the user to access and utilize them.