### PR TITLE
Fix typing a command triggers the `didChange` method

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -977,6 +977,7 @@ end
 
 function onBeforeTextEvent(buf, tevent)
     if next(activeConnections) == nil then return end
+    if buf.Type.Kind ~= buffer.BTDefault then return end
 
     local changes = {}
     for _, delta in userdataIterator(tevent.Deltas) do


### PR DESCRIPTION
The buffer received was the `Log` one. Filtering by `Type.Kind` fixes the issue. 

Closes #27.