### PR TITLE
Simpler and more reliable completions

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -434,8 +434,8 @@ function LSPClient:handleResponseResult(method, result)
         end
 
         if #completions == 0 then
-            display_info("No completions")
-            -- TODO: fall back to micro's built-in completer
+            -- fall back to micro's built-in completer
+            micro.CurPane():Autocomplete()
         else
             -- turn completions into Completer function for micro
             -- https://pkg.go.dev/github.com/zyedidia/micro/v2/internal/buffer#Completer


### PR DESCRIPTION
* gets rid of the old silly and unreliable system where a global variable was used to track the location of the last line where completions were requested
* ~~fallback to micro's built-in autocomplete when language servers don't return any completions no longer works~~
* use micro's built-in `buf:GetWord()` method to get the stem of the completions instead of having the logic in Lua
* use `buf:Autocomplete` instead of directly modifying `buf.Suggestions` and `buf.Completions` and `buf.CurSuggestion`