### PR TITLE
Fix tab insertion when `tabAutocomplete` is true

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1052,8 +1052,8 @@ function preInsertTab(bufpane)
     if not settings.tabAutocomplete then return end
     if findClient(bufpane.Buf:FileType(), "completionProvider") == nil then return end
 
-    local word, wordStartX = bufpane.Buf:GetWord()
-    if wordStartX >= 0 then
+    local word = bufpane.Buf:GetWord()
+    if #word > 0 then
         return false -- returning false prevents tab from being inserted
     end
 end


### PR DESCRIPTION
Given this C code (should not matter):

```c
// replace '@' with hashtag
@define _INPUT(X, ...) 				                \
    enum var blah;\
    //            ^--- here
```

You can't insert a tab between the semicolon and the backslash if `tabAutocomplete` is enabled.

This was caused because `GetWord()` (`./internal/buffer/autocomplete.go`) returns an empty array of bytes ([]byte{}) when it fails, but the integer returned changes depending on which condition failed.

By checking the length of the array of bytes, it's resolved.