### PR TITLE
Implement textDocument/rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The plugin currently provides following commands:
 - `lsp find-references` - find all references to the symbol under cursor (shows the results in a new pane)
 - `lsp document-symbols` - list all symbols in the current document
 - `lsp diagnostic-info` - show more information about a diagnostic on the current line (useful for multiline diagnostic messages)
+- `lsp rename new_name` - renames the symbol under cursor to `new_name`. Without
+  arguments the `lsp rename` command will prompt for a new name.
 
 You can type the commands on micro command prompt or bind them to keys by adding
 something like this to your `bindings.json`:
@@ -68,7 +70,7 @@ something like this to your `bindings.json`:
 - [x] go to type definition
 - [x] find references
 - [x] list document symbols
-- [ ] rename symbol
+- [x] rename symbol
 - [ ] code actions
 - [x] incremental document synchronization (better performance when editing large files)
 - [ ] [suggest a feature](https://github.com/Andriamanitra/mlsp/issues/new)

--- a/main.lua
+++ b/main.lua
@@ -27,6 +27,14 @@ local MessageType = {
     Debug   = 5,
 }
 
+-- https://github.com/zyedidia/micro/blob/bf255b6c353f6a8abf7b5520b5620c52b2f5f2fb/internal/buffer/eventhandler.go#L18-L23
+---@enum TextEventType
+local TextEventType = {
+    INSERT = 1,
+    REMOVE = -1,
+    REPLACE = 0
+}
+
 function init()
     -- ordering of the table affects the autocomplete suggestion order
     local subcommands = {
@@ -128,10 +136,6 @@ local LSPRange = {
     toLocs = function(range)
         local a, b = range["start"], range["end"]
         return buffer.Loc(a.character, a.line), buffer.Loc(b.character, b.line)
-    end,
-    startEqualEnd = function(range)
-        local s, e = range["start"], range["end"]
-        return s.character == e.character and s.line == e.line
     end
 }
 
@@ -414,31 +418,20 @@ function LSPClient:handleResponseResult(method, result)
         else
             display_info("WARNING: Ignored textDocument/hover result due to unrecognized format")
         end
-
-    --- TODO merge textDocument/formatting and textDocument/rangeFormatting?? Same response
     elseif method == "textDocument/formatting" then
         if result == nil or next(result) == nil then
             display_info("Formatted file (no changes)")
         else
             local textedits = result
-            applyLSPTextEdits(micro.CurPane().Buf, textedits)
+            applyTextEdits(micro.CurPane().Buf, textedits)
             display_info("Formatted file")
         end
     elseif method == "textDocument/rangeFormatting" then
         if result == nil or next(result) == nil then
             display_info("Formatted selection (no changes)")
         else
-            local bufpane = micro.CurPane()
-            local buf = bufpane.Buf
-            local cursor = buf:GetActiveCursor()
-            -- maybe there is a nice way to keep multicursors and selections? for now let's
-            -- just get rid of them before editing the buffer to avoid weird behavior
-            buf:ClearCursors()
-            cursor:Deselect(true)
-            cursor = -cursor -- To keep the value
             local textedits = result
-            applyLSPTextEdits(buf, textedits)
-            bufpane:GotoLoc(cursor.Loc)
+            applyTextEdits(micro.CurPane().Buf, textedits)
             display_info("Formatted selection")
         end
     elseif method == "textDocument/completion" then
@@ -585,20 +578,14 @@ function LSPClient:handleResponseResult(method, result)
         showSymbolLocations("[µlsp] document symbols", symbolLocations, symbolLabels)
     elseif method == "textDocument/rename" then
         if result == nil or table.empty(result) then
-            display_info("No change was required for renameAction")
+            display_info("Renamed symbol (no changes required)")
             return
         end
 
-        --https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceEdit
-        --NOTE: "If the client can handle versioned document edits and if
-        --`documentChanges` are present, the latter are preferred over `changes`."
-        if result.documentChanges ~= nil and not table.empty(result.documentChanges) then
-            -- TODO handle result.documentChanges
-            display_error("'documentChanges' is not supported yet")
-        elseif result.changes ~= nil and not table.empty(result.changes) then
-            applyLSPChanges(result.changes)
+        if applyWorkspaceEdit(result) then
+            display_info("Renamed symbol")
         else
-            display_info("No changes received from client for renameAction")
+            display_error("Renaming symbol may not have worked properly")
         end
     else
         log("WARNING: dunno what to do with response to", method)
@@ -872,21 +859,28 @@ function renameAction(bufpane, args)
     local cursor = buf:GetActiveCursor()
     cursor:Deselect(true) -- selection isn't preserved; place the cursor at the start
 
-    local newName
-    if #args > 0 then newName = args[1]
-    else -- `lsp rename`
-        local prompt = ("[µlsp] rename symbol at (%d:%d) with: "):format(cursor.Y + 1, cursor.X + 1)
-        micro.InfoBar():Prompt(prompt, "", "µlsp-rename-symbol", nil, function(str, canceled)
-            if not canceled then renameAction(bufpane, {str}) end
-        end)
-        return
+    local function renameTo(newName)
+        client:request("textDocument/rename", {
+            textDocument = client:textDocumentIdentifier(buf),
+            position = { line = cursor.Y, character = cursor.X },
+            newName = newName,
+        })
     end
 
-    client:request("textDocument/rename", {
-        textDocument = client:textDocumentIdentifier(buf),
-        position = { line = cursor.Y, character = cursor.X },
-        newName = newName,
-    })
+    local newName
+    if #args > 0 then -- `lsp rename newName`
+        renameTo(args[1])
+    else -- `lsp rename`
+        micro.InfoBar():Prompt(
+            string.format("[µlsp] rename symbol at line %d column %d to: ", cursor.Y + 1, cursor.X + 1),
+            "", -- placeholder
+            "µlsp-rename-symbol", -- prompt type (prompts with same type share history)
+            nil, -- event callback
+            function(newName, canceled) -- done callback
+                if not canceled then renameTo(newName) end
+            end 
+        )
+    end
 end
 
 function completionAction(bufpane)
@@ -1175,9 +1169,6 @@ function onRedo(bp)
     return handleUndosRedos(bp.Buf, bp.Buf.UndoStack.Top, numRedos)
 end
 
----@enum TEXT_EVENT
-local TEXT_EVENT = {INSERT = 1, REMOVE = -1, REPLACE = 0}
-
 function handleUndosRedos(buf, elem, numChanges)
     if next(activeConnections) == nil then return end
 
@@ -1194,10 +1185,10 @@ function handleUndosRedos(buf, elem, numChanges)
             local text = ""
             local range = LSPRange.fromDelta(delta)
 
-            if tev.EventType == TEXT_EVENT.INSERT then
+            if tev.EventType == TextEventType.INSERT then
                 range["end"] = range["start"]
                 text = util.String(delta.Text)
-            elseif tev.EventType == TEXT_EVENT.REPLACE then
+            elseif tev.EventType == TextEventType.REPLACE then
                 -- mimics `ExecuteTextEvent()`: https://github.com/zyedidia/micro/blob/f49487dc3adf82ec5e63bf1b6c0ffaed268aa747/internal/buffer/eventhandler.go#L116
                 text = util.String(buf:Substr(-delta.Start, -delta.End))
                 range["end"] = {
@@ -1520,9 +1511,14 @@ end
 
 ---@param buf Buffer
 ---@param edits TextEdit[]
-function applyLSPTextEdits(buf, edits)
+function applyTextEdits(buf, edits)
     -- From https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEditArray
-    -- "Text edits ranges must never overlap, that means no part of the original document must be manipulated by more than one edit. However, it is possible that multiple edits have the same start position: multiple inserts, or any number of inserts followed by a single remove or replace edit. If multiple inserts have the same position, the order in the array defines the order in which the inserted strings appear in the resulting text."
+    -- "Text edits ranges must never overlap, that means no part of the original
+    -- document must be manipulated by more than one edit. However, it is possible
+    -- that multiple edits have the same start position: multiple inserts, or any
+    -- number of inserts followed by a single remove or replace edit. If multiple
+    -- inserts have the same position, the order in the array defines the order in
+    -- which the inserted strings appear in the resulting text."
 
     ---To avoid invalidating locations we sort bottom to top and right to left
     ---@param A TextEdit
@@ -1530,21 +1526,8 @@ function applyLSPTextEdits(buf, edits)
     ---@return boolean -- perform swap?
     local function sortEditsLastFirst(A, B)
         local as, bs = A.range.start, B.range.start
-        return as.line  > bs.line
+        return as.line > bs.line
            or (as.line == bs.line and as.character >= bs.character)
-    end
-
-    ---Returns the kind of edit (TextEdit) for micro.
-    ---@param edit TextEdit
-    ---@return TEXT_EVENT -- Type of micro text event
-    local function textEditType(edit)
-        if edit.newText == "" then
-            return TEXT_EVENT.REMOVE
-        elseif LSPRange.startEqualEnd(edit.range) then
-            return TEXT_EVENT.INSERT
-        else
-            return TEXT_EVENT.REPLACE
-        end
     end
 
     table.sort(edits, sortEditsLastFirst)
@@ -1552,29 +1535,64 @@ function applyLSPTextEdits(buf, edits)
     for i, edit in ipairs(edits) do
         local startLoc, endLoc = LSPRange.toLocs(edit.range)
 
-        local type = textEditType(edit)
-        if type == TEXT_EVENT.INSERT then
-            buf:Insert(startLoc, edit.newText)
-        elseif type == TEXT_EVENT.REMOVE then
+        if edit.newText == "" then
             buf:Remove(startLoc, endLoc)
-        else -- TEXT_EVENT.REPLACE
+        elseif startLoc.Y == endLoc.Y and startLoc.X == endLoc.X then
+            buf:Insert(startLoc, edit.newText)
+        else
+            local cursorsToFix = {}
+            for _, cursor in userdataIterator(buf:GetCursors()) do
+                local curLoc = -cursor.Loc
+                if startLoc:LessEqual(curLoc) and curLoc:LessEqual(endLoc) then
+                    cursorsToFix[cursor] = startLoc:Move(startLoc:Diff(curLoc, buf), buf)
+                end
+            end
+
             buf:Replace(startLoc, endLoc, edit.newText)
+
+            for cursor, newLoc in pairs(cursorsToFix) do
+                cursor:GotoLoc(newLoc)
+            end
         end
     end
 end
 
----@param changes WorkspaceEdit.changes
-function applyLSPChanges(changes)
-    for fileUri, edits in pairs(changes) do
-        local absPath = absPathFromFileUri(fileUri)
-        local bufpane, _, _ = findBufPaneByPath(absPath)
+function applyWorkspaceEdit(workspaceEdit)
+    -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceEdit
+    -- workspaceEdit contains either:
+    -- * changes?: { [uri: DocumentUri]: TextEdit[]; };
+    -- OR
+    -- * documentChanges?: (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[]
 
-        if bufpane then
-            -- TODO add support for new lines in `micro.MultipleReplace(deltas)`
-            applyLSPTextEdits(bufpane.Buf, edits)
+    local failures = 0
+
+    for documentUri, textedits in pairs(workspaceEdit.changes or {}) do
+        local absPath = absPathFromFileUri(documentUri)
+        local bufpane, _, _ = findBufPaneByPath(absPath)
+        if bufpane ~= nil then
+            applyTextEdits(bufpane.Buf, textedits)
         else
-            -- TODO handle bufpane that are not opened!!!!!
-            micro.Log(("applyWorkspaceChanges: %s is not open"):format(absPath))
+            failures = failures + 1
+            log("ERROR: Unable to apply workspace edit for document with uri", documentUri)
         end
     end
+
+    for _, textDocumentEdit in ipairs(workspaceEdit.documentChanges or {}) do
+        if textDocumentEdit.kind ~= nil then
+            -- FIXME: support CreateFile, RenameFile, DeleteFile
+            log("WARNING: Skipping unsupported textDocumentEdit:", textDocumentEdit.kind)
+            failures = failures + 1
+        else
+            local absPath = absPathFromFileUri(textDocumentEdit.textDocument.uri)
+            local bufpane, _, _ = findBufPaneByPath(absPath)
+            if bufpane ~= nil then
+                applyTextEdits(bufpane.Buf, textDocumentEdit.edits)
+            else
+                failures = failures + 1
+                log("ERROR: Unable to apply workspace edit for textdocument", textDocumentEdit.textDocument)
+            end
+        end
+    end
+
+    return failures == 0
 end


### PR DESCRIPTION
This is continues the work in #23 (rebased on top of main & squashed)

* Implemented & documented textDocument/rename request and `lsp rename` command
* Improved editBuf (should be better at keeping cursors where they should be when eg. formatting document)
* Add support for WorkspaceEdit (adapted from the implementation in the experimental [add-menus](https://github.com/Andriamanitra/mlsp/tree/add-menus) branch) which will also be used for code actions

closes #21 