### PR TITLE
Avoid name collisions between hover's buffer names

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -639,7 +639,7 @@ function hoverAction(bufpane)
         ---@param result? Hover
         onResult = function(result)
             local showHoverInfo = function(data)
-                local bf = buffer.NewBuffer(data, "[µlsp] hover")
+                local bf = buffer.NewBuffer(data, "[µlsp] hover-" .. os.time())
                 bf.Type.Scratch = true
                 bf.Type.Readonly = true
                 bufpane:HSplitIndex(bf, true)


### PR DESCRIPTION
If you use `lsp hover` multiple times on different identifiers without closing the buffer, as the buffer name keeps being the same, it opens the same buffer again. To avoid the name conflict, the timestamp is appended to the name.