### PR TITLE
add formatOnSave setting

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -157,6 +157,10 @@ settings = {
     -- key in ~/.config/micro/bindings.json even if this setting is false)
     tabAutocomplete = false,
 
+    -- Send LSP format request when a file is saved. Does nothing if none of the
+    -- active language servers support formatting.
+    formatOnSave = true,
+
     -- Automatically start language server(s) when a buffer with matching
     -- filetype is opened
     autostart = {

--- a/main.lua
+++ b/main.lua
@@ -1161,6 +1161,7 @@ function preSave(bufpane)
         return
     end
 
+    local filetype = bufpane.Buf:FileType()
     local client = findClient(filetype, "documentFormattingProvider", "formatting")
     if not client then return end
 
@@ -1172,7 +1173,6 @@ function preSave(bufpane)
         trimFinalNewlines = true
     }
 
-    local filetype = bufpane.Buf:FileType()
     local method = "textDocument/formatting"
 
     local req = Request(method, {


### PR DESCRIPTION
closes #71 

## TODO:

* [x] Create a method for formatting request that both `preSave` and `formatAction` can use
* [x] #66 causes "[µlsp] No results" to be logged when saving a file that doesn't require any formatting, so that should be fixed before this can be merged
* [ ] Test with different language servers and big files that require lots of formatting to make sure there are no catastrophic bugs
* [ ] Change default value of `formatOnSave` in config to `false`