### PR TITLE
deserialize null into json.null instead of nil

### DIFF
--- a/json.lua
+++ b/json.lua
@@ -165,7 +165,7 @@ local literals      = create_set("true", "false", "null")
 local literal_map = {
   [ "true"  ] = true,
   [ "false" ] = false,
-  [ "null"  ] = nil,
+  [ "null"  ] = null,
 }
 
 

--- a/main.lua
+++ b/main.lua
@@ -648,7 +648,7 @@ function hoverAction(bufpane)
             -- result.contents being a string or array is deprecated but as of 2023
             -- * pylsp still responds with {"contents": ""} for no results
             -- * lua-lsp still responds with {"contents": []} for no results
-            if result == nil or result.contents == "" or table.empty(result.contents) then
+            if result == json.null or result.contents == "" or table.empty(result.contents) then
                 display_info("No hover results")
             elseif type(result.contents) == "string" then -- MarkedString
                 showHoverInfo(result.contents)
@@ -702,7 +702,7 @@ function formatAction(bufpane)
         })
         ---@param result? TextEdit[]
         onResult = function(result)
-            if result == nil or next(result) == nil then
+            if result == json.null or next(result) == nil then
                 display_info("Formatted file (no changes)")
             else
                 local textedits = result
@@ -723,7 +723,7 @@ function formatAction(bufpane)
         })
         ---@param result? TextEdit[]
         onResult = function(result)
-            if result == nil or next(result) == nil then
+            if result == json.null or next(result) == nil then
                 display_info("Formatted selection (no changes)")
             else
                 local textedits = result
@@ -756,7 +756,7 @@ function renameAction(bufpane, args)
     local handler = {
         ---@param result? WorkspaceEdit
         onResult = function(result)
-            if result == nil or table.empty(result) then
+            if result == json.null or table.empty(result) then
                 display_info("Renamed symbol (no changes required)")
                 return
             end
@@ -816,7 +816,7 @@ function completionAction(bufpane)
         onResult = function(result)
             -- TODO: handle result.isIncomplete = true somehow
             local completionitems = {}
-            if result ~= nil then
+            if result ~= json.null then
                 -- result can be either CompletionItem[] or an object
                 -- { isIncomplete: bool, items: CompletionItem[] }
                 completionitems = result.items or result
@@ -895,7 +895,7 @@ function gotoAction(kind)
         client:request(req, {
             ---@param result? Location | Location[] | LocationLink[]
             onResult = function(result)
-                if result == nil or table.empty(result) then
+                if result == json.null or table.empty(result) then
                     display_info(("%s not found"):format(kind))
                 else
                     gotoLSPLocation(result)
@@ -922,7 +922,7 @@ function findReferencesAction(bufpane)
     client:request(req, {
         ---@param result? Location[]
         onResult = function(result)
-            if result == nil or table.empty(result) then
+            if result == json.null or table.empty(result) then
                 display_info("No references found")
                 return
             end
@@ -944,7 +944,7 @@ function documentSymbolsAction(bufpane)
     client:request(req, {
         ---@param result? DocumentSymbol[]
         onResult = function(result)
-            if result == nil or table.empty(result) then
+            if result == json.null or table.empty(result) then
                 display_info("No symbols found in current document")
                 return
             end


### PR DESCRIPTION
Before this change both `{"key": null}` and `{}` would become `{}` in Lua. Now they will become `{ key = json.null }` and `{}` respectively, so we can finally differentiate between null values and missing keys (unfortunately a meaningful distinction in some parts of the language server protocol).

This needs extensive testing, I went through all the nils in the source code and changed the ones that come from LSP responses (JSON) but I'm not at all confident that I haven't missed something.

closes #66