### PR TITLE
Add setting for whether to open a new tab for goto-definition

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -150,6 +150,12 @@ for _, server in pairs(languageServer) do
 end
 
 
+-- Modes for how goto-definition displays the target buffer
+gotoMode = {
+    newTab      = "newTab",
+    currentPane = "currentPane",
+}
+
 settings = {
 
     -- Use LSP completion in place of micro's default Autocomplete action when
@@ -200,6 +206,8 @@ settings = {
         hint        = false
     },
 
-    -- Open a new tab when jumping to definition
-    newTabGotoDefinition = true,
+    -- How to display the target buffer when jumping to definition:
+    --   gotoMode.newTab        - open the target in a new tab (default)
+    --   gotoMode.currentPane   - replace the current pane's buffer
+    gotoMode = gotoMode.newTab,
 }

--- a/config.lua
+++ b/config.lua
@@ -199,4 +199,7 @@ settings = {
         information = false,
         hint        = false
     },
+
+    -- Open a new tab when jumping to definition
+    newTabGotoDefinition = true,
 }

--- a/config.lua
+++ b/config.lua
@@ -152,7 +152,7 @@ end
 
 -- Modes for how goto-definition displays the target buffer
 gotoMode = {
-    newTab      = "newTab",
+    default     = "default",
     currentPane = "currentPane",
 }
 
@@ -207,7 +207,7 @@ settings = {
     },
 
     -- How to display the target buffer when jumping to definition:
-    --   gotoMode.newTab        - open the target in a new tab (default)
+    --   gotoMode.default       - reuse open buffers if they exist, otherwise open a new tab
     --   gotoMode.currentPane   - replace the current pane's buffer
-    gotoMode = gotoMode.newTab,
+    gotoMode = gotoMode.default,
 }

--- a/main.lua
+++ b/main.lua
@@ -1489,7 +1489,7 @@ function openFileAtLoc(filePath, loc)
             display_error(err)
             return
         end
-        if settings.gotoMode == gotoMode.newTab then
+        if settings.gotoMode == gotoMode.default then
             micro.CurPane():AddTab()
         end
         bp = micro.CurPane()

--- a/main.lua
+++ b/main.lua
@@ -1488,7 +1488,9 @@ function openFileAtLoc(filePath, loc)
             display_error(err)
             return
         end
-        micro.CurPane():AddTab()
+        if settings.newTabGotoDefinition then
+            micro.CurPane():AddTab()
+        end
         bp = micro.CurPane()
         bp:OpenBuffer(newBuf)
     end

--- a/main.lua
+++ b/main.lua
@@ -10,6 +10,7 @@ local go_strings = import("strings")
 local go_filepath = import("path/filepath")
 
 local settings = settings
+local gotoMode = gotoMode
 local json = json
 
 local activeConnections = {}
@@ -1488,7 +1489,7 @@ function openFileAtLoc(filePath, loc)
             display_error(err)
             return
         end
-        if settings.newTabGotoDefinition then
+        if settings.gotoMode == gotoMode.newTab then
             micro.CurPane():AddTab()
         end
         bp = micro.CurPane()


### PR DESCRIPTION
I have a workflow where I only use a single buffer and use [MicroOmni's cursor history](https://github.com/Neko-Box-Coder/MicroOmni#-global-cursor-history) to jump back and forth and so it's convenient to have `lsp goto-definition` replace the current buffer instead of opening a new tab.

This PR just makes that configurable via `settings.newTabGotoDefinition`, with the default being the current behaviour.